### PR TITLE
Change of Vehicle Assets in Side Missions 

### DIFF
--- a/SIDEscripts/Missions/fn_gamsar.sqf
+++ b/SIDEscripts/Missions/fn_gamsar.sqf
@@ -43,7 +43,7 @@ nul = [_side_log_pos,1,false,1,[1,0],100,"default",nil,"pilot1 = this; removeAll
 
 nul = [_side_log_pos,2,true,2,[2,2],_side_rad,_side_ai_skill_array,nil,nil,nil] execVM "LV\fillHouse.sqf";
 nul = [_side_log_pos,2,_side_rad,[true,false],[true,false,false],false,[10,0],[0,0],_side_ai_skill_array,nil,nil,nil] execVM "LV\militarize.sqf";
-nul = [_side_log_pos,2,_side_rad,[true,false],[true,false,true],true,[0,0],[1,0],_side_ai_skill_array,nil,nil,nil] execVM "LV\militarize.sqf";
+nul = [_side_log_pos,2,_side_rad,[true,false],[true,false,false],true,[0,0],[1,0],_side_ai_skill_array,nil,nil,nil] execVM "LV\militarize.sqf";
 
 //////////////// create triggers at side mission ////////////////////////////////////////////////////////////////////////////////////////			
 

--- a/SIDEscripts/Missions/fn_lalezar.sqf
+++ b/SIDEscripts/Missions/fn_lalezar.sqf
@@ -33,7 +33,7 @@ nul = [cache1,2,20,[true,false],[false,false,false],false,[2,0],[0,0],_side_ai_s
 
 nul = [_side_log_pos,2,true,2,[2,2],_side_rad,_side_ai_skill_array,nil,nil,nil] execVM "LV\fillHouse.sqf";
 nul = [_side_log_pos,2,_side_rad,[true,false],[true,false,false],false,[10,0],[0,0],_side_ai_skill_array,nil,nil,nil] execVM "LV\militarize.sqf";
-nul = [_side_log_pos,2,_side_rad,[true,false],[true,false,true],true,[0,0],[1,0],_side_ai_skill_array,nil,nil,nil] execVM "LV\militarize.sqf";
+nul = [_side_log_pos,2,_side_rad,[true,false],[true,false,false],true,[0,0],[1,0],_side_ai_skill_array,nil,nil,nil] execVM "LV\militarize.sqf";
 
 //////////////// create trigger at the side ////////////////////////////////////////////////////////////////////////////////////////			
 


### PR DESCRIPTION
Get rid of Air Vehicles in Side Missions and change it to Ground Vehicles only.
